### PR TITLE
Make RAILS able to find SLICOT on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,17 @@ matrix:
       env:
          - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 
+    - os: osx
+      osx_image: xcode10.2
+      addons:
+        homebrew:
+          taps: nlesc/nlesc
+          packages:
+            - ccache
+          update: true
+      before_install:
+         - brew install nlesc/nlesc/slicot
+
 before_install:
   - eval "${MATRIX_EVAL}"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(RAILS C CXX)
 
+list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/CMakeModules)
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   message(STATUS "Using GNU compiler flags")
 
@@ -55,6 +57,7 @@ set(HEADERS ${HEADERS}
 
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
+find_package(SLICOT REQUIRED)
 
 find_package(Trilinos QUIET)
 
@@ -98,7 +101,7 @@ include_directories(${PROJECT_SOURCE_DIR})
 set(BUILD_SHARED_LIBS ON)
 
 add_library(rails ${SOURCES})
-target_link_libraries(rails "slicot")
+target_link_libraries(rails ${SLICOT_LIB})
 target_link_libraries(rails ${BLAS_LIBRARIES})
 target_link_libraries(rails ${LAPACK_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(RAILS C CXX)
+set(CMAKE_CXX_STANDARD 11)
 
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/CMakeModules)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ include_directories(${PROJECT_SOURCE_DIR})
 set(BUILD_SHARED_LIBS ON)
 
 add_library(rails ${SOURCES})
-target_link_libraries(rails ${SLICOT_LIB})
+target_link_libraries(rails ${SLICOT_LIBRARIES})
 target_link_libraries(rails ${BLAS_LIBRARIES})
 target_link_libraries(rails ${LAPACK_LIBRARIES})
 

--- a/CMakeModules/FindSLICOT.cmake
+++ b/CMakeModules/FindSLICOT.cmake
@@ -1,0 +1,33 @@
+SET(SLICOT_LIB_SEARCH_PATHS
+        /lib/
+        /lib64/
+        /usr/lib/
+        /usr/lib64/
+        /usr/local/lib
+        /usr/local/lib64
+ )
+
+FIND_LIBRARY(SLICOT_LIB NAMES slicot slicot64 PATHS ${SLICOT_LIB_SEARCH_PATHS})
+
+SET(SLICOT_FOUND ON)
+
+#    Check libraries
+IF(NOT SLICOT_LIB)
+    SET(SLICOT_FOUND OFF)
+    MESSAGE(STATUS "Could not find SLICOT lib. Turning SLICOT off")
+ENDIF()
+
+IF (SLICOT_FOUND)
+  IF (NOT SLICOT_FIND_QUIETLY)
+      MESSAGE(STATUS "Found SLICOT libraries: ${SLICOT_LIB}")
+  ENDIF (NOT SLICOT_FIND_QUIETLY)
+ELSE (SLICOT_FOUND)
+  IF (SLICOT_FIND_REQUIRED)
+    MESSAGE(FATAL_ERROR "Could not find SLICOT")
+  ENDIF (SLICOT_FIND_REQUIRED)
+ENDIF (SLICOT_FOUND)
+
+MARK_AS_ADVANCED(
+    SLICOT_LIB
+    SLICOT
+)

--- a/CMakeModules/FindSLICOT.cmake
+++ b/CMakeModules/FindSLICOT.cmake
@@ -1,33 +1,44 @@
-SET(SLICOT_LIB_SEARCH_PATHS
-        /lib/
-        /lib64/
-        /usr/lib/
-        /usr/lib64/
-        /usr/local/lib
-        /usr/local/lib64
- )
+# - Find the SLICOT library
+#
+# This module defines
+#  SLICOT_LIBRARIES, the libraries to link against to use SLICOT.
+#  SLICOT_FOUND, If false, do not try to use SLICOT.
+# also defined, but not for general use are
+#  SLICOT_LIBRARY, where to find the SLICOT library.
 
-FIND_LIBRARY(SLICOT_LIB NAMES slicot slicot64 PATHS ${SLICOT_LIB_SEARCH_PATHS})
+#=============================================================================
+# Copyright 2010, Martin Koehler
+# http://www-user.tu-chemnitz.de/~komart/
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
 
-SET(SLICOT_FOUND ON)
+if (WIN32)
+	set(_libdir ENV LIB)
+elseif (APPLE)
+	set(_libdir ENV DYLD_LIBRARY_PATH)
+else ()
+	set(_libdir ENV LD_LIBRARY_PATH)
+endif ()
 
-#    Check libraries
-IF(NOT SLICOT_LIB)
-    SET(SLICOT_FOUND OFF)
-    MESSAGE(STATUS "Could not find SLICOT lib. Turning SLICOT off")
-ENDIF()
+set(SLICOT_NAMES slicot)
+#set(SLICOT_PATH /usr/local/lib /usr/lib )
+find_library(SLICOT_LIBRARY NAMES ${SLICOT_NAMES} PATHS ${_libdir} )
 
-IF (SLICOT_FOUND)
-  IF (NOT SLICOT_FIND_QUIETLY)
-      MESSAGE(STATUS "Found SLICOT libraries: ${SLICOT_LIB}")
-  ENDIF (NOT SLICOT_FIND_QUIETLY)
-ELSE (SLICOT_FOUND)
-  IF (SLICOT_FIND_REQUIRED)
-    MESSAGE(FATAL_ERROR "Could not find SLICOT")
-  ENDIF (SLICOT_FIND_REQUIRED)
-ENDIF (SLICOT_FOUND)
+if (SLICOT_LIBRARY)
+	SET(SLICOT_LIBRARIES ${SLICOT_LIBRARY} ${LAPACK_LIBRARIES})
+	SET(SLICOT_FOUND true)
+endif (SLICOT_LIBRARY)
 
-MARK_AS_ADVANCED(
-    SLICOT_LIB
-    SLICOT
-)
+
+# handle the QUIETLY and REQUIRED arguments and set SLICOT_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SLICOT  DEFAULT_MSG SLICOT_LIBRARY )
+
+mark_as_advanced(SLICOT_LIBRARY )

--- a/src/StlTools.hpp
+++ b/src/StlTools.hpp
@@ -1,6 +1,7 @@
 #ifndef STLTOOLS_H
 #define STLTOOLS_H
 
+#include <cmath>
 #include <utility>
 #include <vector>
 #include <algorithm>

--- a/test/GenericMultiVectorWrapper_test.cpp
+++ b/test/GenericMultiVectorWrapper_test.cpp
@@ -2,6 +2,7 @@
 
 #include "TestHelpers.hpp"
 
+#include <cmath>
 #include "src/StlWrapper.hpp"
 
 #ifdef ENABLE_TRILINOS

--- a/test/GenericOperatorWrapper_test.cpp
+++ b/test/GenericOperatorWrapper_test.cpp
@@ -2,6 +2,7 @@
 
 #include "TestHelpers.hpp"
 
+#include <cmath>
 #include "src/StlWrapper.hpp"
 
 #ifdef ENABLE_TRILINOS


### PR DESCRIPTION
i-emic linux tests are broken, because I didn't run RAILS dependent tests on macOS, so this is an initial step to include the RAILS tests on macOS travis too.